### PR TITLE
loosen @swc/core version in  package.json

### DIFF
--- a/vite-plugin/package.json
+++ b/vite-plugin/package.json
@@ -43,7 +43,7 @@
     "vite": "^5"
   },
   "dependencies": {
-    "@swc/core": "1.6.7",
+    "@swc/core": "^1.6.7",
     "debug": "^4.3.4",
     "oxc-resolver": "1.9.3",
     "swc-plugin-barrel": "workspace:*"


### PR DESCRIPTION
This should address #18 as the new swc/core I think fixes this:

https://github.com/swc-project/swc/discussions/4023